### PR TITLE
Just the kernels

### DIFF
--- a/singlekernel.py
+++ b/singlekernel.py
@@ -22,8 +22,13 @@ from tornado import web
 
 from tornado.log import app_log
 
+from IPython.kernel.kernelspec import KernelSpecManager
+
 from IPython.html.services.kernels.kernelmanager import MappingKernelManager
-from IPython.html.services.kernels.handlers import default_handlers
+from IPython.html.services.kernels.handlers import default_handlers as kernels_handlers
+from IPython.html.services.kernelspecs.handlers import default_handlers as kernelspecs_handlers
+
+default_handlers = kernels_handlers + kernelspecs_handlers
         
 def fix_base_path(base_path):
     if not base_path.startswith('/'):
@@ -75,6 +80,7 @@ def main():
         headers=headers,
         allow_origin=allow_origin,
         allow_origin_pat=allow_origin_pat,
+        kernel_spec_manager=KernelSpecManager(),
     )
 
     app = WebApp(kernel_manager, settings)

--- a/singlekernel.py
+++ b/singlekernel.py
@@ -24,6 +24,7 @@ from tornado.log import app_log
 
 from IPython.html.services.kernels.kernelmanager import MappingKernelManager
 from IPython.html.services.kernels.handlers import (
+    MainKernelHandler,
     KernelHandler, KernelActionHandler,
     ZMQChannelsHandler,
 )
@@ -45,6 +46,7 @@ class WebApp(web.Application):
         base_path = settings['base_path']
 
         handlers = [
+            (url_path_join(base_path, r"/api/kernels"), MainKernelHandler),
             (url_path_join(base_path, r"/api/kernels/%s" % _kernel_id_regex), KernelHandler),
             (url_path_join(base_path, r"/api/kernels/%s/%s" % (_kernel_id_regex, _kernel_action_regex)), KernelActionHandler),
             (url_path_join(base_path, r"/api/kernels/%s/channels" % _kernel_id_regex), ZMQChannelsHandler),


### PR DESCRIPTION
This PR does away with the title of this repository, exposing the full IPython/Jupyter kernels API. This means you can just request a kernel type directly:

``` python
In [1]: import requests

In [2]: requests.post("http://docker:8000/krn/api/kernels", json={'name': 'python2'}).json()
Out[2]: {'id': '019bb6ed-3d7d-42d4-9baf-cc7e25c35938', 'name': 'python2'}

In [3]: requests.post("http://docker:8000/krn/api/kernels", json={'name': 'python3'}).json()
Out[3]: {'id': '23ce3d7a-b444-4d41-92a4-992dca518f44', 'name': 'python3'}
```

Should I just add the kernelspecs API too?
